### PR TITLE
snap/pack: add check to disallow packing snapd, core (os) and base snaps with configure hooks

### DIFF
--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -837,6 +837,22 @@ version: 1.0`
 	c.Assert(err, ErrorMatches, ".*invalid hook name.*")
 }
 
+func (s *infoSuite) TestReadInfoFromSnapFileCatchesImplicitHookDefaultConfigureOnly(c *C) {
+	yaml := `name: foo
+version: 1.0`
+
+	contents := [][]string{
+		{"meta/hooks/default-configure", ""},
+	}
+	sideInfo := &snap.SideInfo{}
+	snapInfo := snaptest.MockSnapWithFiles(c, yaml, sideInfo, contents)
+	snapf, err := snapfile.Open(snapInfo.MountDir())
+	c.Assert(err, IsNil)
+
+	_, err = snap.ReadInfoFromSnapFile(snapf, nil)
+	c.Assert(err, ErrorMatches, "cannot specify \"default-configure\" hook without \"configure\" hook")
+}
+
 func (s *infoSuite) checkInstalledSnapAndSnapFile(c *C, instanceName, yaml string, contents string, hooks []string, checker func(c *C, info *snap.Info)) {
 	// First check installed snap
 	sideInfo := &snap.SideInfo{Revision: snap.R(42)}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -824,9 +824,13 @@ hooks:
 func (s *infoSuite) TestReadInfoFromSnapFileCatchesInvalidImplicitHook(c *C) {
 	yaml := `name: foo
 version: 1.0`
-	snapPath := snaptest.MakeTestSnapWithFiles(c, yaml, emptyHooks("123abc"))
 
-	snapf, err := snapfile.Open(snapPath)
+	contents := [][]string{
+		{"meta/hooks/123abc", ""},
+	}
+	sideInfo := &snap.SideInfo{}
+	snapInfo := snaptest.MockSnapWithFiles(c, yaml, sideInfo, contents)
+	snapf, err := snapfile.Open(snapInfo.MountDir())
 	c.Assert(err, IsNil)
 
 	_, err = snap.ReadInfoFromSnapFile(snapf, nil)

--- a/snap/pack/pack.go
+++ b/snap/pack/pack.go
@@ -107,8 +107,8 @@ func CheckSkeleton(w io.Writer, sourceDir string) error {
 }
 
 func loadAndValidate(sourceDir string) (*snap.Info, error) {
-	// Extraction of snap info is duplicated in ReadInfoFromSnapFile, this is done
-	// only to extract the snap instance name, if available, to use in case of
+	// Parsing of snap info is duplicated in ReadInfoFromSnapFile. It is done
+	// here to retrieve the snap instance name, if available, to use in case of
 	// ReadInfoFromSnapFile error
 	yaml, err := ioutil.ReadFile(filepath.Join(sourceDir, "meta", "snap.yaml"))
 	if err != nil {
@@ -122,9 +122,10 @@ func loadAndValidate(sourceDir string) (*snap.Info, error) {
 
 	// ReadInfoFromSnapFile covers the following required steps:
 	// 	- Read snap metadata from meta/snap.yaml
-	//      - Extract snap info from meta/snap.yaml, without populating side info
-	//      - Add implicit hooks from meta/hooks, and validate hooks individually
+	//      - Parse snap info from meta/snap.yaml without side info
+	//      - Add and bind implicit hooks from meta/hooks
 	//      - Validate available snap information
+	//      - Validate snapshot metadata from opional meta/snapshot.yaml
 	info, err = snap.ReadInfoFromSnapFile(snapdir.New(sourceDir), nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot validate snap %q: %v", instanceName, err)

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -162,6 +162,22 @@ func ValidateLicense(license string) error {
 	return nil
 }
 
+func validateHooks(info *Info) error {
+	for _, hook := range info.Hooks {
+		if err := ValidateHook(hook); err != nil {
+			return err
+		}
+	}
+
+	hasDefaultConfigureHook := info.Hooks["default-configure"] != nil
+	hasConfigureHook := info.Hooks["configure"] != nil
+	if hasDefaultConfigureHook && !hasConfigureHook {
+		return fmt.Errorf(`cannot specify "default-configure" hook without "configure" hook`)
+	}
+
+	return nil
+}
+
 // ValidateHook validates the content of the given HookInfo
 func ValidateHook(hook *HookInfo) error {
 	if err := naming.ValidateHook(hook.Name); err != nil {
@@ -368,11 +384,9 @@ func Validate(info *Info) error {
 		}
 	}
 
-	// validate hook entries
-	for _, hook := range info.Hooks {
-		if err := ValidateHook(hook); err != nil {
-			return err
-		}
+	// Validate hook entries
+	if err := validateHooks(info); err != nil {
+		return err
 	}
 
 	// Ensure that plugs and slots have appropriate names and interface names.

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -793,6 +793,18 @@ hooks:
 	c.Check(err, ErrorMatches, `invalid hook name: "123abc"`)
 }
 
+func (s *ValidateSuite) TestIllegalHookDefaultConfigureWithoutConfigure(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`name: foo
+version: 1.0
+hooks:
+  default-configure:
+`))
+	c.Assert(err, IsNil)
+
+	err = Validate(info)
+	c.Check(err, ErrorMatches, "cannot specify \"default-configure\" hook without \"configure\" hook")
+}
+
 func (s *ValidateSuite) TestPlugSlotNamesUnique(c *C) {
 	info, err := InfoFromSnapYaml([]byte(`name: snap
 version: 0


### PR DESCRIPTION
This change is currently based on related pending PR: https://github.com/snapcore/snapd/pull/13097

This is a partial implementation of spec: https://docs.google.com/document/d/1qQsxCrhlCKUb33_1mdY88sRHeFZStFnydh7mirA3S0Y/edit?usp=drive_link
"Prohibit user-defined configuration hooks for specific essential snaps"

**Unit tests and testing outstanding**