### PR TITLE
docs: add Cursor Cloud specific dev environment instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -365,3 +365,14 @@ func (iface *myInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
 4. **Conflicts prevent concurrent ops**: Check `snapstate/conflict.go` for snap operation serialization
 5. **Backend abstraction**: Use `snapstate/backend` for disk state, never manipulate directly
 6. **Interface security profiles are additive**: Each connected interface adds to AppArmor/seccomp profiles
+
+## Cursor Cloud specific instructions
+
+The dependency-refresh update script only runs `go mod download`. Everything else below is set up once in the VM snapshot (apt build deps such as `libseccomp-dev`, `libcap-dev`, `libapparmor-dev`, `libudev-dev`, `libfuse3-dev`, `xfslibs-dev`, autotools, `golangci-lint` in `~/go/bin`). Assume the toolchain is present; do not reinstall system packages.
+
+- **Build/test/lint** work natively here. Prefix test runs with `LANG=C.UTF-8` (some tests fail on other locales). `golangci-lint` lives in `$(go env GOPATH)/bin` — add it to `PATH` or let `./run-checks` auto-install/find it. `./run-checks --unit` and `--static` both work; the full `./run-checks` also runs the C parts (needs `cmd/autogen.sh`).
+- **Running the real `snapd` daemon in this container** works only in *degraded/devmode*: the container has no AppArmor kernel module and no `/var/lib/snapd/snap` mount infrastructure, so `syscheck` fails and any *state-changing* op (e.g. `snap install`) is rejected with "system does not fully support snapd". Read-only REST calls and store queries DO work.
+  - Steps: `go build -o /tmp/build ./...`, then copy the Go helpers snapd needs at startup into the libexec dir once: `sudo cp /tmp/build/{snap-seccomp,snap-exec,snap-update-ns,snap-failure,snapctl,snap-repair,snap-bootstrap,snap-preseed,snapd-apparmor} /usr/lib/snapd/` (missing `snap-seccomp` there causes a startup error). `snap-confine`/`snap-discard-ns` are C binaries (build via `cd cmd && ./autogen.sh && make`) and are not needed for REST-only testing.
+  - Start it with standby disabled or it self-exits when idle (expects systemd socket activation): `sudo SNAPD_STANDBY_WAIT=1h SNAPD_DEBUG=1 /tmp/build/snapd`. It listens on `/run/snapd.socket`.
+  - Then use the client against it: `/tmp/build/snap version`, `/tmp/build/snap debug api /v2/system-info`, `/tmp/build/snap find hello` (live store query).
+- **Full snap install / interface / confinement behavior** cannot be exercised natively here — use the spread integration tests in a VM instead (`./run-spread garden:...`, see the `build-snapd-snap` and `run-spread-test` skills).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the snapd development environment for Cursor Cloud agents. Adds a `## Cursor Cloud specific instructions` section to `.github/copilot-instructions.md` (which `AGENTS.md` symlinks to) capturing the non-obvious startup/run caveats discovered during setup.

The only code change is documentation. The environment itself (apt build deps, `golangci-lint`, Go module cache) is captured in the VM snapshot; the dependency-refresh update script is just `go mod download`.

## Environment verified

- **Build**: `go build -o /tmp/build ./...` builds `snap`, `snapd`, and all helpers including the CGO `snap-seccomp` (libseccomp).
- **Lint**: `golangci-lint run` works (installed via the `run-checks` pin, v2.12.2).
- **Test**: representative unit tests pass (`LANG=C.UTF-8 go test ./strutil/... ./osutil/...`).
- **Run (hello-world)**: the real `snapd` daemon runs in degraded/devmode, seeds state, generates the CA cert DB, and connects to the live snap store. The `snap` client talks to it over the REST API (`snap version`, `snap debug api /v2/system-info`) and a live store search (`snap find hello`) returns results end-to-end.

## Known container limitation

State-changing ops like `snap install` are rejected ("system does not fully support snapd") because the container has no AppArmor kernel module or `/var/lib/snapd/snap` mount infrastructure. Full install/confinement behavior is exercised via spread integration tests in VMs, as documented.

[snapd dev environment end-to-end demo](https://cursor.com/agents/bc-01c895a8-0e7d-49e7-81b7-39c02c86bb64/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsnapd_dev_env_demo.txt)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01c895a8-0e7d-49e7-81b7-39c02c86bb64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01c895a8-0e7d-49e7-81b7-39c02c86bb64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

